### PR TITLE
Update version to 0.1.4, add DawgPayload utility class

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Bohdan Moskalevskyi
+Copyright (c) 2016 msklvsk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dawgjs",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "description": "DAWG reader for node.js and the browser",
   "files": [
     "*.js",
@@ -9,17 +9,18 @@
   "main": "index.node.js",
   "typings": "index.node.d.ts",
   "scripts": {
-    "build:watch": "typings install && /usr/bin/env node node_modules/typescript/bin/tsc -p src -w",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build:w": "typings install && ./node_modules/typescript/bin/tsc -p src -w"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/msklvsk/dawgjs.git"
   },
   "keywords": [
-    "dawg",
-    "dafsa",
+    "DAWG",
+    "DAWG-python",
+    "DAFSA",
     "dawgdic",
+    "data structure",
     "dictionary"
   ],
   "author": "Bohdan Moskalevskyi <msklvsk@icloud.com>",
@@ -29,6 +30,9 @@
   },
   "homepage": "https://github.com/msklvsk/dawgjs#readme",
   "devDependencies": {
-    "typescript": "^1.8.10"
+    "tslint": "^4.3.1",
+    "tslint-eslint-rules": "^3.2.3",
+    "tslint-microsoft-contrib": "^4.0.0",
+    "typescript": "^2.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/msklvsk/dawgjs#readme",
   "devDependencies": {
+    "@types/node": "12.12.6",
     "tslint": "^4.3.1",
     "tslint-eslint-rules": "^3.2.3",
     "tslint-microsoft-contrib": "^4.0.0",

--- a/src/byte_completion_dawg.ts
+++ b/src/byte_completion_dawg.ts
@@ -7,7 +7,7 @@ import { ByteDawg } from './byte_dawg';
 export class ByteCompletionDawg extends ByteDawg {
   constructor(
       public dictionary: Dictionary,
-      protected guide: Guide) {
+      public guide: Guide) {
     super(dictionary);
   }
 
@@ -35,7 +35,7 @@ export class ByteCompletionDawg extends ByteDawg {
 
 
 //------------------------------------------------------------------------------
-function* completer(dic: Dictionary, guide: Guide, index: number) {
+export function* completer(dic: Dictionary, guide: Guide, index: number) {
   let completion = new Array<number>();
   let indexStack = [index];
   while (indexStack.length) {
@@ -87,7 +87,7 @@ function* completer(dic: Dictionary, guide: Guide, index: number) {
 
 
 //------------------------------------------------------------------------------
-function completerArray(dic: Dictionary, guide: Guide, index: number) {
+export function completerArray(dic: Dictionary, guide: Guide, index: number) {
   let ret = new Array();
   let completion = new Array();
   let indexStack = [index];

--- a/src/byte_completion_dawg.ts
+++ b/src/byte_completion_dawg.ts
@@ -6,7 +6,7 @@ import { ByteDawg } from './byte_dawg';
 
 export class ByteCompletionDawg extends ByteDawg {
   constructor(
-      dictionary: Dictionary,
+      public dictionary: Dictionary,
       protected guide: Guide) {
     super(dictionary);
   }

--- a/src/byte_dawg.ts
+++ b/src/byte_dawg.ts
@@ -3,7 +3,7 @@ import { Dictionary } from './dictionary';
 
 
 export class ByteDawg {
-  constructor(protected dictionary: Dictionary) {
+  constructor(public dictionary: Dictionary) {
   }
 
   hasBytes(value: Iterable<number>) {

--- a/src/byte_map_dawg.ts
+++ b/src/byte_map_dawg.ts
@@ -21,4 +21,18 @@ export class ByteMapDawg {
       yield b64decodeFromArray(completed);
     }
   }
+  
+  getBytesArray(key: Iterable<number>): Uint8Array[] {
+    
+    let ret = new Array();
+    let completions = this.dawg.completionsBytesArray([...key, this.payloadSeparator]);
+    for (let i = 0; i < completions.length; ++i) {
+      let completed = completions[i];
+      if (this.binasciiWorkaround) {
+        completed = completed.slice(0, -1);
+      }
+      ret.push(b64decodeFromArray(completed));
+    }
+    return ret;
+  }
 }

--- a/src/byte_map_dawg.ts
+++ b/src/byte_map_dawg.ts
@@ -4,7 +4,7 @@ import { b64decodeFromArray } from './codec';
 
 
 export class ByteMapDawg {
-  constructor(protected dawg: ByteCompletionDawg,
+  constructor(public dawg: ByteCompletionDawg,
               protected payloadSeparator = 1,
               protected binasciiWorkaround = false) {  // see https://github.com/kmike/DAWG/issues/21
   }

--- a/src/dawg_payload.ts
+++ b/src/dawg_payload.ts
@@ -1,0 +1,174 @@
+import { readStringMapDawg, readByteCompletionDawg } from './factories';
+
+import { ByteDawg } from './byte_dawg';
+import { ByteMapDawg } from './byte_map_dawg';
+import { MapDawg } from './map_dawg';
+import { ByteCompletionDawg } from './byte_completion_dawg';
+import { encodeUtf8, b64decodeFromArray } from './codec';
+
+export class DawgPayload {
+    private format;
+    private dawgjs_map;
+    private dawgjs_byte;
+
+    constructor(buffer: ArrayBuffer, format: string) {
+        this.format = format;
+
+        if (format === 'words') {
+            this.dawgjs_map = readStringMapDawg(buffer, this.deserializerWord, 1, true);
+        }
+        if (format === 'probs') {
+            this.dawgjs_map = readStringMapDawg(buffer, this.deserializerProbs, 1, true);
+        }
+        if (format === 'int') {
+            this.dawgjs_byte = readByteCompletionDawg(buffer);
+        }
+    }
+    public findAll(str: string, replaces?: { [key: string]: string }): any[] {
+        const results: any[] = [];
+        const prefixes: [string, number[], number, number][] = [['', [], 0, 0]]; // [prefix, utf8, len, index]
+        let prefix: string, encodedPrefix: number[], index: number, len: number, code: number[], cur: number;
+
+        let myDict = undefined;
+        if (this.format === 'int') {
+            myDict = this.dawgjs_byte!.dictionary;
+        }
+        if (this.format === 'probs' || this.format === 'words') {
+            myDict = this.dawgjs_map!.dawg.dawg.dictionary;
+        }
+        if (typeof myDict === "undefined") {
+                throw new Error('DAWG is corrupted!');
+        }
+        while (prefixes.length) {
+            console.log(["prefixes", prefixes]);
+            const currentPrefix = prefixes.pop();
+            console.log(currentPrefix);
+            if (!currentPrefix) continue;
+        
+            [prefix, encodedPrefix, len, index] = currentPrefix;
+            console.log([len, str.length, prefix, encodedPrefix, index]);
+
+            // Done: at the end of the input string
+            if (len === str.length) {
+                if (this.format === 'int') {
+                    if (myDict.hasValue(index)) {
+                        results.push([prefix, myDict.value(index)]);
+                    }
+                    continue;
+                }
+                if (this.format === 'words' || this.format === 'probs') {
+                    // read the payload separated by \x01
+                    console.log(["end of", prefix, encodedPrefix, index]);
+                    const newIndex = myDict.followByte(1, index);
+                    if (newIndex === undefined || newIndex === -1) {
+                        continue;
+                    }
+                    index = newIndex;
+                }
+                let deserializer = (this.format === 'words')? this.deserializerWord : this.deserializerProbs;
+                // console.log(["try", this.dawgjs_map!.dawg!.dawg!.completionsBytesArray(encodedPrefix.concat([1]))]);
+                // results.push([prefix, [...completer(myDict, myGuide, index)] ]);
+                const data = this.dawgjs_map!.dawg!.dawg!.completionsBytesArray(encodedPrefix.concat([1]));
+                const decodedArr: any[] = [];
+                console.log(data.length);
+                data.forEach(d => {
+                    let decoded = b64decodeFromArray(d.slice(0, -1));
+                    decodedArr.push(deserializer(decoded));
+                });
+                results.push([prefix, decodedArr]);
+                continue;
+            }
+
+            // Follow replacement path
+            const currentChar = str[len]!;
+            if (replaces && currentChar in replaces) {
+                code = encodeUtf8(replaces[currentChar]!);
+                cur = myDict.followBytes(code, index);
+                console.log(JSON.stringify([currentChar, "->", replaces[currentChar], code, cur]))
+                if (cur !== undefined || cur !== -1) {
+                    prefixes.push([prefix + replaces[currentChar], encodedPrefix.concat(code), len + 1, cur]);
+                }
+            }
+
+            // Follow base path
+            code = encodeUtf8(currentChar);
+            cur = myDict.followBytes(code, index);
+            console.log(JSON.stringify([currentChar, code, cur]))
+            if (cur !== undefined || cur !== -1) {
+                prefixes.push([prefix + currentChar, encodedPrefix.concat(code), len + 1, cur]);
+            }
+        }
+        console.log(["PREFIXES:", JSON.stringify(prefixes)]);
+        console.log(["RESULTS:", JSON.stringify(results)]);
+        return results;
+    }
+
+    public getInt(str: string): number | undefined {
+        // yes, Az.probabilities.format == "int"
+        // while Az.predictionSuffixes[i].format == "probs"
+        // go figure
+        if (this.format === 'probs' || this.format === 'words' || typeof this.dawgjs_byte === 'undefined') {
+            throw new Error('You are trying to access wrong DAWG type.');
+        }
+        const index = this.dawgjs_byte.dictionary!.followBytes(encodeUtf8(str));
+        const hasValue = this.dawgjs_byte.dictionary!.hasValue(index);
+        const value = this.dawgjs_byte.dictionary!.value(index) ^ (1 << 31);
+
+        if (hasValue && typeof value !== 'undefined') {
+            return value;
+        }
+        return undefined;
+    }
+
+    private getStr(str: string): any[] | undefined {
+        if (this.format === 'int' || typeof this.dawgjs_map === 'undefined') {
+            throw new Error('You are trying to access wrong DAWG type.');
+        }
+        const indexes = this.dawgjs_map.getArray(str);
+
+        if (indexes.length) {
+            return [
+                str,
+                indexes,
+            ];
+        }
+
+        return;
+    }
+    private getAllReplaces(str: string, replaces?: string[][]): string[] {
+        const allReplaces: string[] = [];
+
+        if (!replaces || !replaces.length) {
+            return allReplaces;
+        }
+
+        for (let i = 0; i < str.length; i++) {
+            const char = str[i];
+
+            replaces.forEach(([from, to]) => {
+                if (char === from) {
+                    allReplaces.push(`${str.slice(0, i)}${to}${str.slice(i + 1)}`);
+                }
+            });
+        }
+
+        return allReplaces;
+    }
+    private deserializerWord(bytes: Uint8Array): [number, number] {
+        let view = new DataView(bytes.buffer);
+
+        const paradigmId = view.getUint16(0);
+        const indexInParadigm = view.getUint16(2);
+
+        return [paradigmId, indexInParadigm];
+    }
+    private deserializerProbs(bytes: Uint8Array): [number, number, number] {
+        let view = new DataView(bytes.buffer);
+
+        const paradigmId = view.getUint16(0);
+        const indexInParadigm = view.getUint16(2);
+        const indexInParadigm2 = view.getUint16(4);
+
+        return [paradigmId, indexInParadigm, indexInParadigm2];
+    }
+}

--- a/src/dawg_payload.ts
+++ b/src/dawg_payload.ts
@@ -40,13 +40,10 @@ export class DawgPayload {
                 throw new Error('DAWG is corrupted!');
         }
         while (prefixes.length) {
-            console.log(["prefixes", prefixes]);
             const currentPrefix = prefixes.pop();
-            console.log(currentPrefix);
             if (!currentPrefix) continue;
-        
+
             [prefix, encodedPrefix, len, index] = currentPrefix;
-            console.log([len, str.length, prefix, encodedPrefix, index]);
 
             // Done: at the end of the input string
             if (len === str.length) {
@@ -58,7 +55,6 @@ export class DawgPayload {
                 }
                 if (this.format === 'words' || this.format === 'probs') {
                     // read the payload separated by \x01
-                    console.log(["end of", prefix, encodedPrefix, index]);
                     const newIndex = myDict.followByte(1, index);
                     if (newIndex === undefined || newIndex === -1) {
                         continue;
@@ -66,11 +62,8 @@ export class DawgPayload {
                     index = newIndex;
                 }
                 let deserializer = (this.format === 'words')? this.deserializerWord : this.deserializerProbs;
-                // console.log(["try", this.dawgjs_map!.dawg!.dawg!.completionsBytesArray(encodedPrefix.concat([1]))]);
-                // results.push([prefix, [...completer(myDict, myGuide, index)] ]);
                 const data = this.dawgjs_map!.dawg!.dawg!.completionsBytesArray(encodedPrefix.concat([1]));
                 const decodedArr: any[] = [];
-                console.log(data.length);
                 data.forEach(d => {
                     let decoded = b64decodeFromArray(d.slice(0, -1));
                     decodedArr.push(deserializer(decoded));
@@ -84,7 +77,6 @@ export class DawgPayload {
             if (replaces && currentChar in replaces) {
                 code = encodeUtf8(replaces[currentChar]!);
                 cur = myDict.followBytes(code, index);
-                console.log(JSON.stringify([currentChar, "->", replaces[currentChar], code, cur]))
                 if (cur !== undefined || cur !== -1) {
                     prefixes.push([prefix + replaces[currentChar], encodedPrefix.concat(code), len + 1, cur]);
                 }
@@ -93,13 +85,10 @@ export class DawgPayload {
             // Follow base path
             code = encodeUtf8(currentChar);
             cur = myDict.followBytes(code, index);
-            console.log(JSON.stringify([currentChar, code, cur]))
             if (cur !== undefined || cur !== -1) {
                 prefixes.push([prefix + currentChar, encodedPrefix.concat(code), len + 1, cur]);
             }
         }
-        console.log(["PREFIXES:", JSON.stringify(prefixes)]);
-        console.log(["RESULTS:", JSON.stringify(results)]);
         return results;
     }
 
@@ -134,25 +123,6 @@ export class DawgPayload {
         }
 
         return;
-    }
-    private getAllReplaces(str: string, replaces?: string[][]): string[] {
-        const allReplaces: string[] = [];
-
-        if (!replaces || !replaces.length) {
-            return allReplaces;
-        }
-
-        for (let i = 0; i < str.length; i++) {
-            const char = str[i];
-
-            replaces.forEach(([from, to]) => {
-                if (char === from) {
-                    allReplaces.push(`${str.slice(0, i)}${to}${str.slice(i + 1)}`);
-                }
-            });
-        }
-
-        return allReplaces;
     }
     private deserializerWord(bytes: Uint8Array): [number, number] {
         let view = new DataView(bytes.buffer);

--- a/src/factories.node.ts
+++ b/src/factories.node.ts
@@ -1,11 +1,22 @@
 import { ValueDeserializer, MapDawg } from './map_dawg';
-import { createStringMapDawg } from './factories';
+import { ByteCompletionDawg } from './byte_completion_dawg';
+import { CompletionDawg } from './completion_dawg';
+import { readByteCompletionDawg, readStringCompletionDawg, readStringMapDawg } from './factories';
 
 import { readFileSync } from 'fs';
 
 
 
+
 ////////////////////////////////////////////////////////////////////////////////
-export function createStringMapDawgSync<T>(filename: string, deserializer: ValueDeserializer<T>) {
-  return createStringMapDawg<T>(readFileSync(filename).buffer, deserializer, 1, true);
+export function readByteCompletionDawgSync(filename: string): ByteCompletionDawg {
+    return readByteCompletionDawg(readFileSync(filename).buffer);
+}
+////////////////////////////////////////////////////////////////////////////////
+export function readStringCompletionDawgSync(filename: string): CompletionDawg<string> {
+    return readStringCompletionDawg(readFileSync(filename).buffer);
+}
+////////////////////////////////////////////////////////////////////////////////
+export function readStringMapDawgSync(filename: string, deserializer: ValueDeserializer<T>): MapDawg<string, T> {
+    return readStringMapDawg(readFileSync(filename).buffer, deserializer, 1, true);
 }

--- a/src/factories.node.ts
+++ b/src/factories.node.ts
@@ -17,6 +17,6 @@ export function readStringCompletionDawgSync(filename: string): CompletionDawg<s
     return readStringCompletionDawg(readFileSync(filename).buffer);
 }
 ////////////////////////////////////////////////////////////////////////////////
-export function readStringMapDawgSync(filename: string, deserializer: ValueDeserializer<T>): MapDawg<string, T> {
+export function readStringMapDawgSync<T>(filename: string, deserializer: ValueDeserializer<T>): MapDawg<string, T> {
     return readStringMapDawg(readFileSync(filename).buffer, deserializer, 1, true);
 }

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -4,7 +4,7 @@ import { ByteMapDawg } from './byte_map_dawg';
 import { ByteCompletionDawg } from './byte_completion_dawg';
 import { CompletionDawg } from './completion_dawg';
 import { MapDawg, ValueDeserializer } from './map_dawg';
-import { encodeUtf8 } from './codec';
+import { encodeUtf8, decodeUtf8 } from './codec';
 
 ////////////////////////////////////////////////////////////////////////////////
 export function readByteCompletionDawg(buffer: ArrayBuffer): ByteCompletionDawg {
@@ -20,10 +20,10 @@ export function readByteCompletionDawg(buffer: ArrayBuffer): ByteCompletionDawg 
 }
 ////////////////////////////////////////////////////////////////////////////////
 export function readStringCompletionDawg(buffer: ArrayBuffer): CompletionDawg<string> {
-  return new completion_dawg_1.CompletionDawg(readByteCompletionDawg(buffer), codec_1.encodeUtf8, codec_1.decodeUtf8);
+  return new CompletionDawg(readByteCompletionDawg(buffer), encodeUtf8, decodeUtf8);
 };
 ////////////////////////////////////////////////////////////////////////////////
 export function readStringMapDawg<T>(buffer: ArrayBuffer, deserializer: ValueDeserializer<T>, payloadSeparator = 1, binasciiWorkaround = false): MapDawg<string, T> {
-  let byteMapDawg = new byte_map_dawg_1.ByteMapDawg(readByteCompletionDawg(buffer), payloadSeparator, binasciiWorkaround);
-  return new map_dawg_1.MapDawg(byteMapDawg, codec_1.encodeUtf8, deserializer);
+  let byteMapDawg = new ByteMapDawg(readByteCompletionDawg(buffer), payloadSeparator, binasciiWorkaround);
+  return new MapDawg(byteMapDawg, encodeUtf8, deserializer);
 };

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -2,28 +2,28 @@ import { Dictionary } from './dictionary';
 import { Guide } from './guide';
 import { ByteMapDawg } from './byte_map_dawg';
 import { ByteCompletionDawg } from './byte_completion_dawg';
+import { CompletionDawg } from './completion_dawg';
 import { MapDawg, ValueDeserializer } from './map_dawg';
 import { encodeUtf8 } from './codec';
 
-
-
-export function createStringMapDawg<T>(
-  buf: ArrayBuffer,
-  deserializer: ValueDeserializer<T>,
-  payloadSeparator = 1,
-  binasciiWorkaround = false) {
-
-  let view = new DataView(buf);
-  let dicSize = view.getUint32(0, true);
-  let dicData = new Uint32Array(buf, 4, dicSize);
-  let offset = 4 + dicSize * 4;
+////////////////////////////////////////////////////////////////////////////////
+export function readByteCompletionDawg(buffer: ArrayBuffer): ByteCompletionDawg {
+  let view = new DataView(buffer);
+  let dictSize = view.getUint32(0, true);
+  // console.error(buffer.byteLength)
+  let dictData = new Uint32Array(buffer, 4, dictSize);
+  let offset = 4 + dictSize * 4;
   let guideSize = view.getUint32(offset, true) * 2;
-  let guideData = new Uint8Array(buf, offset + 4, guideSize);
+  let guideData = new Uint8Array(buffer, offset + 4, guideSize);
 
-  let byteMapDawg = new ByteMapDawg(
-    new ByteCompletionDawg(new Dictionary(dicData), new Guide(guideData)),
-    payloadSeparator,
-    binasciiWorkaround);
-
-  return new MapDawg<string, T>(byteMapDawg, encodeUtf8, deserializer);
+  return new ByteCompletionDawg(new Dictionary(dictData), new Guide(guideData));
 }
+////////////////////////////////////////////////////////////////////////////////
+export function readStringCompletionDawg(buffer: ArrayBuffer): CompletionDawg<string> {
+  return new completion_dawg_1.CompletionDawg(readByteCompletionDawg(buffer), codec_1.encodeUtf8, codec_1.decodeUtf8);
+};
+////////////////////////////////////////////////////////////////////////////////
+export function readStringMapDawg<T>(buffer: ArrayBuffer, deserializer: ValueDeserializer<T>, payloadSeparator = 1, binasciiWorkaround = false): MapDawg<string, T> {
+  let byteMapDawg = new byte_map_dawg_1.ByteMapDawg(readByteCompletionDawg(buffer), payloadSeparator, binasciiWorkaround);
+  return new map_dawg_1.MapDawg(byteMapDawg, codec_1.encodeUtf8, deserializer);
+};

--- a/src/map_dawg.ts
+++ b/src/map_dawg.ts
@@ -23,4 +23,8 @@ export class MapDawg<K, V> {
       yield this.valueDeserializer(value);
     }
   }
+  
+  getArray(key: K): V[] {
+    return this.dawg.getBytesArray(this.keyEncoder(key)).map(x => this.valueDeserializer(x));
+  }
 }

--- a/src/map_dawg.ts
+++ b/src/map_dawg.ts
@@ -9,7 +9,7 @@ export interface ValueDeserializer<V> {
 
 export class MapDawg<K, V> {
   constructor(
-    protected dawg: ByteMapDawg,
+    public dawg: ByteMapDawg,
     protected keyEncoder: (key: K) => Iterable<number>,
     protected valueDeserializer: ValueDeserializer<V>) {
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "outDir": "..",
+    "outDir": "dist/dawgjs",
     "declaration": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,11 @@
     "declaration": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "include": [
+    "./src/"
+  ],
+  "exclude": [
+    "node_modules/*"
+  ]
 }


### PR DESCRIPTION
1) as noted in https://github.com/msklvsk/dawgjs/issues/2, the npm version is 0.1.4 while the Github code is still on 0.1.2. I reverse engineered and backported diffs between 0.1.2 and 0.1.4 releases on npm, now source should reflect published package

2) for  the current interface of `dawgjs` isn't really convenient for `pymorphy2`-related things, it is too low-level. I created new class DawgPayload that provides a high-level wrapper around these. Partly based on Az.ts, partly backported from Az.js, partly summoned from the depths of R'Lyeh.